### PR TITLE
Allow nested arrays of children for m function

### DIFF
--- a/src/mithril/M.hx
+++ b/src/mithril/M.hx
@@ -137,6 +137,9 @@ typedef JSONPOptions = {
 @:final @:native("m")
 extern class M
 {
+	@:overload(function(selector : String, ?attributes : Dynamic, ?children : Array<Array<{subtree: String}>>) : VirtualElement {})
+	@:overload(function(selector : String, ?attributes : Dynamic, ?children : Array<Array<VirtualElement>>) : VirtualElement {})
+	@:overload(function(selector : String, ?attributes : Dynamic, ?children : Array<Array<String>>) : VirtualElement {})
 	@:overload(function(selector : String, ?attributes : Dynamic, ?children : Array<{subtree: String}>) : VirtualElement {})
 	@:overload(function(selector : String, ?attributes : Dynamic, ?children : Array<VirtualElement>) : VirtualElement {})
 	@:overload(function(selector : String, ?attributes : Dynamic, ?children : Array<String>) : VirtualElement {})


### PR DESCRIPTION
Mithril seems to allow you to pass a nested array in the m function, and it seems to flatten the array internally.  I thought it might be useful to allow this in mithril-hx, but this is completely up to you if you want to do this or not.

Example taken from mithril page here: http://lhorie.github.io/mithril/getting-started.html.  The table element creates an array for children, then does a map inside that array which creates a nested array.

```js
//here's the view
m("table", [
    todo.vm.list.map(function(task, index) {
        return m("tr", [
            m("td", [
                m("input[type=checkbox]")
            ]),
            m("td", task.description()),
        ])
    })
])
```

In mithril-hx, you get a compile error if you use the nested array with an attributes object like this:

```haxe
m("table", { config: Something.config }, [
  something().map(function() {
    return m(...);
  })
]);
```

I think It actually works without the attributes object, because the children object is being treated as the Dynamic optional attributes, rather than as the `Array<Array<VirtualElement>>`