### PR TITLE
Changed xhr request extract function return type from `String` to `Dynamic` to reflect actual Mithril.js

### DIFF
--- a/src/haxelib.json
+++ b/src/haxelib.json
@@ -4,7 +4,7 @@
   "url" : "https://github.com/ciscoheat/mithril-hx",
   "license": "MIT",
   "tags": ["js", "mvc", "web"],
-  "releasenote": "Now supports Mithril 1.0!",
-  "version": "1.0.0",
+  "releasenote": "Changed xhr request extract function return type from `String` to `Dynamic` to reflect actual Mithril.js",
+  "version": "1.0.1",
   "contributors": ["ciscoheat"]
 }

--- a/src/mithril/M.hx
+++ b/src/mithril/M.hx
@@ -81,7 +81,7 @@ typedef XHROptions<T, T2, T3> = {
 	@:optional var type : T -> Dynamic;
 	@:optional var serialize : T3 -> String;
 	@:optional var deserialize : String -> T3;
-	@:optional var extract : XMLHttpRequest -> XHROptions<T, T2, T3> -> String;
+	@:optional var extract : XMLHttpRequest -> XHROptions<T, T2, T3> -> Dynamic;
 	@:optional var useBody : Bool;
 	@:optional var background : Bool;
 };


### PR DESCRIPTION
I was playing around with the xhr.request, trying to get xhr status codes in case of error. To do so in Mithril, you have to use the extract function: https://mithril.js.org/request.html#retrieving-response-details

Mithril expects this to return an object, Mithril-hx expects this to return a string. This pull request changes Mithril-hx to make the `extract` function return a `Dynamic` instead of a `String`.