### PR TITLE
Convert `untyped __js__` calls to `js.Syntax.code`

### DIFF
--- a/src/mithril/macros/ModuleBuilder.hx
+++ b/src/mithril/macros/ModuleBuilder.hx
@@ -79,8 +79,12 @@ class ModuleBuilder
 		switch(f.expr.expr) {
 			case EBlock(exprs):
 				exprs.unshift(macro
+					#if (haxe_ver < 4.0)
 					// Needs to be untyped to avoid clashing with macros that modify return (particularly HaxeContracts)
 					untyped __js__('if(arguments.length > 0 && arguments[0].tag != this) return arguments[0].tag.$methodName.apply(arguments[0].tag, arguments)')
+					#else
+					js.Syntax.code('if(arguments.length > 0 && arguments[0].tag != this) return arguments[0].tag.$methodName.apply(arguments[0].tag, arguments)')
+					#end
 				);
 			case _:
 				f.expr = {expr: EBlock([f.expr]), pos: f.expr.pos};


### PR DESCRIPTION
Haxe 4.1.0 deprecated `untyped __js__(code, args)` calls
(https://haxe.org/download/version/4.1.0/), which means using this
library with newer versions of the Haxe compiler spits out a ton of
annoying warnings.

The changes in this commit remain backwards compatible with Haxe 3 (which
did not have the `js.Syntax` type), in that case the library still uses
`untyped __js__` calls.