### PR TITLE
Add overloads for m() function to flesh out the definition

### DIFF
--- a/src/mithril/M.hx
+++ b/src/mithril/M.hx
@@ -118,6 +118,8 @@ typedef JSONPOptions<T, T2> = {
 extern class M
 {
 	@:overload(function(selector : Mithril) : Vnodes {})
+	@:overload(function(selector : Mithril, attributes : Dynamic) : Vnodes {})
+	@:overload(function(selector : Mithril, attributes : Dynamic, children : Dynamic) : Vnodes {})
 	@:overload(function(selector : Either<String, Component>) : Vnodes {})
 	@:overload(function(selector : Either<String, Component>, attributes : Dynamic) : Vnodes {})
 	public static function m(selector : Either<String, Component>, attributes : Dynamic, children : Dynamic) : Vnodes;

--- a/src/mithril/M.hx
+++ b/src/mithril/M.hx
@@ -120,6 +120,9 @@ extern class M
 	@:overload(function(selector : Mithril) : Vnodes {})
 	@:overload(function(selector : Mithril, attributes : Dynamic) : Vnodes {})
 	@:overload(function(selector : Mithril, attributes : Dynamic, children : Dynamic) : Vnodes {})
+	@:overload(function(selector : Class<Mithril>) : Vnodes {})
+	@:overload(function(selector : Class<Mithril>, attributes : Dynamic) : Vnodes {})
+	@:overload(function(selector : Class<Mithril>, attributes : Dynamic, children : Dynamic) : Vnodes {})
 	@:overload(function(selector : Either<String, Component>) : Vnodes {})
 	@:overload(function(selector : Either<String, Component>, attributes : Dynamic) : Vnodes {})
 	public static function m(selector : Either<String, Component>, attributes : Dynamic, children : Dynamic) : Vnodes;


### PR DESCRIPTION
Add a few overloads to M.m to allow the selector to always be something that implements `Mithril`, whether it has attributes & children or not, and allow static classes to work as selectors if they implement `Mithril`.